### PR TITLE
Don't hard code gnome-terminal

### DIFF
--- a/acestream-launcher.patch
+++ b/acestream-launcher.patch
@@ -35,11 +35,11 @@
  Name=AceStream Launcher
  GenericName=Media player
  Comment=Open AceStream links with any Media Player
--Exec=acestream-launcher %u
-+Exec=gnome-terminal -- acestream-launcher %u
+ Exec=acestream-launcher %u
  TryExec=acestream-launcher
  Icon=multimedia-video-player
- Terminal=false
+-Terminal=false
++Terminal=true
  Type=Application
 -MimeType=x-scheme-handler/acestream;
 +MimeType=x-scheme-handler/acestream;application/x-acelive;


### PR DESCRIPTION
 * why force the use of gnome-terminal when desktop files provide a `Terminal=` key